### PR TITLE
chore: Exclude .github folder from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.github/           export-ignore
 /tests/             export-ignore
 .editorconfig       export-ignore
 .gitattributes      export-ignore


### PR DESCRIPTION
The `.github` folder should not be included in the composer package.

This PR ensures it will be excluded from the export.