### PR TITLE
feat: Add support for PHP 8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ ubuntu-latest, macos-latest, windows-latest ]
-                php: [ 8.1 ]
+                php: [ 8.1, 8.0 ]
                 stability: [ lowest, stable ]
         steps:
             - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.23",

--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -15,13 +15,13 @@ class Chunk
      * @param array<string> $dynamicImports
      */
     public function __construct(
-        public readonly string $file,
-        public readonly bool $isEntry = false,
-        public readonly bool $isDynamicEntry = false,
-        public readonly ?string $src = null,
-        public readonly array $css = [],
-        public readonly array $assets = [],
-        public readonly array $imports = [],
-        public readonly array $dynamicImports = [],
+        public string $file,
+        public bool $isEntry = false,
+        public bool $isDynamicEntry = false,
+        public ?string $src = null,
+        public array $css = [],
+        public array $assets = [],
+        public array $imports = [],
+        public array $dynamicImports = [],
     ) {}
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -3,17 +3,22 @@
 namespace Laravite\Manifest;
 
 use Laravite\Manifest\Exception\EntryNotFound;
+use RuntimeException;
 
+/**
+ * @property-read array<Chunk> $chunks
+ * @property-read array<Chunk> $entries
+ */
 class Manifest
 {
     /** @var array<Chunk> */
-    public readonly array $entries;
+    private array $entries;
 
     /**
      * @param array<Chunk> $chunks
      */
     public function __construct(
-        public readonly array $chunks,
+        private array $chunks,
     ) {
         $this->entries = array_filter(
             $this->chunks,
@@ -37,5 +42,14 @@ class Manifest
         $json = json_decode($json, true);
         $chunks = array_map(fn (array $chunk) => new Chunk(...$chunk), $json);
         return new self($chunks);
+    }
+
+    public function __get(string $property): mixed
+    {
+        return match ($property) {
+            'chunks' => $this->chunks,
+            'entries' => $this->entries,
+            default => throw new RuntimeException("Undefined property $property"),
+        };
     }
 }


### PR DESCRIPTION
This PR introduces support for PHP 8.0.

I originally intented to support only PHP 8.1+ but since this library is so small, lowering the PHP version requirement makes sense to me.